### PR TITLE
refactor: prepare named catalog for submoduling

### DIFF
--- a/apps/svelte-kit/package.json
+++ b/apps/svelte-kit/package.json
@@ -20,19 +20,19 @@
   },
   "dependencies": {
     "@svebcomponents/example-component": "workspace:*",
-    "@svebcomponents/ssr": "catalog:"
+    "@svebcomponents/ssr": "catalog:template"
   },
   "devDependencies": {
     "@svebcomponents/eslint-config": "workspace:*",
     "@svebcomponents/prettier-config": "workspace:*",
     "@svebcomponents/typescript-config": "workspace:*",
-    "@sveltejs/adapter-auto": "catalog:",
-    "@sveltejs/kit": "catalog:",
-    "@sveltejs/vite-plugin-svelte": "catalog:",
-    "globals": "catalog:",
-    "svelte": "catalog:",
-    "svelte-check": "catalog:",
-    "typescript": "catalog:",
-    "vite": "catalog:"
+    "@sveltejs/adapter-auto": "catalog:template",
+    "@sveltejs/kit": "catalog:template",
+    "@sveltejs/vite-plugin-svelte": "catalog:template",
+    "globals": "catalog:template",
+    "svelte": "catalog:template",
+    "svelte-check": "catalog:template",
+    "typescript": "catalog:template",
+    "vite": "catalog:template"
   }
 }

--- a/components/example-component/package.json
+++ b/components/example-component/package.json
@@ -17,14 +17,14 @@
     "check-types": "svelte-check"
   },
   "devDependencies": {
-    "@svebcomponents/build": "catalog:",
-    "@svebcomponents/ssr": "catalog:",
+    "@svebcomponents/build": "catalog:template",
+    "@svebcomponents/ssr": "catalog:template",
     "@svebcomponents/prettier-config": "workspace:*",
     "@svebcomponents/eslint-config": "workspace:*",
     "@svebcomponents/typescript-config": "workspace:*",
-    "rollup": "catalog:",
-    "svelte": "catalog:",
-    "svelte-check": "catalog:",
-    "vite": "catalog:"
+    "rollup": "catalog:template",
+    "svelte": "catalog:template",
+    "svelte-check": "catalog:template",
+    "vite": "catalog:template"
   }
 }

--- a/configs/eslint-config/package.json
+++ b/configs/eslint-config/package.json
@@ -17,12 +17,12 @@
   },
   "devDependencies": {
     "@eslint/compat": "1.2.8",
-    "@eslint/js": "catalog:",
+    "@eslint/js": "catalog:template",
     "@svebcomponents/prettier-config": "workspace:*",
-    "eslint": "catalog:",
-    "eslint-config-prettier": "catalog:",
-    "eslint-plugin-svelte": "catalog:",
-    "globals": "catalog:",
-    "typescript-eslint": "catalog:"
+    "eslint": "catalog:template",
+    "eslint-config-prettier": "catalog:template",
+    "eslint-plugin-svelte": "catalog:template",
+    "globals": "catalog:template",
+    "typescript-eslint": "catalog:template"
   }
 }

--- a/configs/prettier-config/package.json
+++ b/configs/prettier-config/package.json
@@ -14,7 +14,7 @@
     "./svelte": "./src/svelte.js"
   },
   "dependencies": {
-    "prettier": "catalog:",
-    "prettier-plugin-svelte": "catalog:"
+    "prettier": "catalog:template",
+    "prettier-plugin-svelte": "catalog:template"
   }
 }

--- a/configs/typescript-config/package.json
+++ b/configs/typescript-config/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@svebcomponents/prettier-config": "workspace:*",
-    "@tsconfig/strictest": "catalog:",
-    "@tsconfig/svelte": "catalog:"
+    "@tsconfig/strictest": "catalog:template",
+    "@tsconfig/svelte": "catalog:template"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     "release": "turbo build && pnpx @changesets/cli publish"
   },
   "devDependencies": {
-    "eslint": "catalog:",
-    "prettier": "catalog:",
-    "turbo": "catalog:"
+    "eslint": "catalog:template",
+    "prettier": "catalog:template",
+    "turbo": "catalog:template"
   },
   "packageManager": "pnpm@10.8.0+sha512.0e82714d1b5b43c74610193cb20734897c1d00de89d0e18420aebc5977fa13d780a9cb05734624e81ebd81cc876cd464794850641c48b9544326b5622ca29971",
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 catalogs:
-  default:
+  template:
     '@eslint/js':
       specifier: 9.24.0
       version: 9.24.0
@@ -85,13 +85,13 @@ importers:
         version: link:../../Library/pnpm/global/5/node_modules/@svebcomponents/ssr
     devDependencies:
       eslint:
-        specifier: 'catalog:'
+        specifier: catalog:template
         version: 9.24.0
       prettier:
-        specifier: 'catalog:'
+        specifier: catalog:template
         version: 3.5.3
       turbo:
-        specifier: 'catalog:'
+        specifier: catalog:template
         version: 2.5.2
 
   apps/svelte-kit:
@@ -100,7 +100,7 @@ importers:
         specifier: workspace:*
         version: link:../../components/example-component
       '@svebcomponents/ssr':
-        specifier: 'catalog:'
+        specifier: catalog:template
         version: 0.0.5(rollup@4.40.0)(svelte@5.28.2)
     devDependencies:
       '@svebcomponents/eslint-config':
@@ -113,34 +113,34 @@ importers:
         specifier: workspace:*
         version: link:../../configs/typescript-config
       '@sveltejs/adapter-auto':
-        specifier: 'catalog:'
+        specifier: catalog:template
         version: 6.0.0(@sveltejs/kit@2.20.5(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.28.2)(vite@6.2.6(@types/node@22.14.1)))(svelte@5.28.2)(vite@6.2.6(@types/node@22.14.1)))
       '@sveltejs/kit':
-        specifier: 'catalog:'
+        specifier: catalog:template
         version: 2.20.5(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.28.2)(vite@6.2.6(@types/node@22.14.1)))(svelte@5.28.2)(vite@6.2.6(@types/node@22.14.1))
       '@sveltejs/vite-plugin-svelte':
-        specifier: 'catalog:'
+        specifier: catalog:template
         version: 5.0.3(svelte@5.28.2)(vite@6.2.6(@types/node@22.14.1))
       globals:
-        specifier: 'catalog:'
+        specifier: catalog:template
         version: 16.0.0
       svelte:
-        specifier: 'catalog:'
+        specifier: catalog:template
         version: 5.28.2
       svelte-check:
-        specifier: 'catalog:'
+        specifier: catalog:template
         version: 4.1.6(picomatch@4.0.2)(svelte@5.28.2)(typescript@5.8.3)
       typescript:
-        specifier: 'catalog:'
+        specifier: catalog:template
         version: 5.8.3
       vite:
-        specifier: 'catalog:'
+        specifier: catalog:template
         version: 6.2.6(@types/node@22.14.1)
 
   components/example-component:
     devDependencies:
       '@svebcomponents/build':
-        specifier: 'catalog:'
+        specifier: catalog:template
         version: 0.0.4(@svebcomponents/ssr@0.0.5(rollup@4.40.0)(svelte@5.28.2))(rollup@4.40.0)(svelte@5.28.2)
       '@svebcomponents/eslint-config':
         specifier: workspace:*
@@ -149,22 +149,22 @@ importers:
         specifier: workspace:*
         version: link:../../configs/prettier-config
       '@svebcomponents/ssr':
-        specifier: 'catalog:'
+        specifier: catalog:template
         version: 0.0.5(rollup@4.40.0)(svelte@5.28.2)
       '@svebcomponents/typescript-config':
         specifier: workspace:*
         version: link:../../configs/typescript-config
       rollup:
-        specifier: 'catalog:'
+        specifier: catalog:template
         version: 4.40.0
       svelte:
-        specifier: 'catalog:'
+        specifier: catalog:template
         version: 5.28.2
       svelte-check:
-        specifier: 'catalog:'
+        specifier: catalog:template
         version: 4.1.6(picomatch@4.0.2)(svelte@5.28.2)(typescript@5.8.3)
       vite:
-        specifier: 'catalog:'
+        specifier: catalog:template
         version: 6.2.6(@types/node@22.14.1)
 
   configs/eslint-config:
@@ -173,34 +173,34 @@ importers:
         specifier: 1.2.8
         version: 1.2.8(eslint@9.24.0)
       '@eslint/js':
-        specifier: 'catalog:'
+        specifier: catalog:template
         version: 9.24.0
       '@svebcomponents/prettier-config':
         specifier: workspace:*
         version: link:../prettier-config
       eslint:
-        specifier: 'catalog:'
+        specifier: catalog:template
         version: 9.24.0
       eslint-config-prettier:
-        specifier: 'catalog:'
+        specifier: catalog:template
         version: 10.1.2(eslint@9.24.0)
       eslint-plugin-svelte:
-        specifier: 'catalog:'
+        specifier: catalog:template
         version: 3.5.1(eslint@9.24.0)(svelte@5.28.2)
       globals:
-        specifier: 'catalog:'
+        specifier: catalog:template
         version: 16.0.0
       typescript-eslint:
-        specifier: 'catalog:'
+        specifier: catalog:template
         version: 8.29.1(eslint@9.24.0)(typescript@5.8.3)
 
   configs/prettier-config:
     dependencies:
       prettier:
-        specifier: 'catalog:'
+        specifier: catalog:template
         version: 3.5.3
       prettier-plugin-svelte:
-        specifier: 'catalog:'
+        specifier: catalog:template
         version: 3.3.3(prettier@3.5.3)(svelte@5.28.2)
 
   configs/typescript-config:
@@ -209,10 +209,10 @@ importers:
         specifier: workspace:*
         version: link:../prettier-config
       '@tsconfig/strictest':
-        specifier: 'catalog:'
+        specifier: catalog:template
         version: 2.0.5
       '@tsconfig/svelte':
-        specifier: 'catalog:'
+        specifier: catalog:template
         version: 5.0.4
 
 packages:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,29 +2,31 @@ packages:
   - apps/*
   - components/*
   - configs/*
-catalog:
-  "@svebcomponents/build": 0.0.4
-  "@svebcomponents/ssr": 0.0.5
-  "@svebcomponents/auto-options": 0.0.4
-  "@sveltejs/adapter-auto": 6.0.0
-  "@sveltejs/kit": 2.20.5
-  "@sveltejs/package": 2.3.10
-  "@sveltejs/vite-plugin-svelte": 5.0.3
-  "@tsconfig/strictest": 2.0.5
-  "@tsconfig/svelte": 5.0.4
-  "@types/node": 22.14.1
-  eslint: 9.24.0
-  "@eslint/js": 9.24.0
-  eslint-config-prettier: 10.1.2
-  eslint-plugin-svelte: 3.5.1
-  globals: 16.0.0
-  prettier: 3.5.3
-  prettier-plugin-svelte: 3.3.3
-  rollup: 4.40.0
-  svelte: 5.28.2
-  svelte-check: 4.1.6
-  turbo: 2.5.2
-  typescript: 5.8.3
-  typescript-eslint: 8.29.1
-  vite: 6.2.6
-  vitest: 3.1.1
+catalogs:
+  # we use a named catalog to allow easily including it in the pnpm-workspace.yaml of a monorepo submoduling this repo
+  template:
+    "@svebcomponents/build": 0.0.4
+    "@svebcomponents/ssr": 0.0.5
+    "@svebcomponents/auto-options": 0.0.4
+    "@sveltejs/adapter-auto": 6.0.0
+    "@sveltejs/kit": 2.20.5
+    "@sveltejs/package": 2.3.10
+    "@sveltejs/vite-plugin-svelte": 5.0.3
+    "@tsconfig/strictest": 2.0.5
+    "@tsconfig/svelte": 5.0.4
+    "@types/node": 22.14.1
+    eslint: 9.24.0
+    "@eslint/js": 9.24.0
+    eslint-config-prettier: 10.1.2
+    eslint-plugin-svelte: 3.5.1
+    globals: 16.0.0
+    prettier: 3.5.3
+    prettier-plugin-svelte: 3.3.3
+    rollup: 4.40.0
+    svelte: 5.28.2
+    svelte-check: 4.1.6
+    turbo: 2.5.2
+    typescript: 5.8.3
+    typescript-eslint: 8.29.1
+    vite: 6.2.6
+    vitest: 3.1.1


### PR DESCRIPTION
since [@svebcomponents/svebcomponents](https://github.com/svebcomponents/svebcomponents) will submodule this template repo going forward, I decided to give the catalog inside our template a name, so that it can be easily extended upon from the `workspace-pnpm.yaml` of a repo submoduling this repo